### PR TITLE
Add GitHub Actions for PyPI publishing

### DIFF
--- a/githubctl/.github/workflows/publish-to-pypi.yml
+++ b/githubctl/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Related to #2

Adds GitHub Actions workflow for building and uploading the package to PyPI.

- **Workflow Configuration**: Introduces a new workflow file `publish-to-pypi.yml` under `.github/workflows` to automate the package deployment process.
- **Trigger Event**: Configures the workflow to trigger on push events to the `main` branch.
- **Build and Publish Job**: Defines a job that runs on `ubuntu-latest`, which includes steps for checking out the code, setting up Python 3.9, installing dependencies (setuptools, wheel, twine), building the package, and publishing it to PyPI using a PyPI API token for authentication.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xiaopeng163/githubctl/issues/2?shareId=63cce0e0-b7c8-49b1-997b-3a57c8247d04).